### PR TITLE
Catalog pagination search, CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize]
+  push:
+    branches: [master]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - run: npm run lint
+
+      - run: cp .env.example .env
+
+      - run: docker compose up -d --build
+
+      - name: Wait for API to be ready
+        run: |
+          for i in $(seq 1 60); do
+            if curl -s -o /dev/null -w "%{http_code}" http://localhost:3000/doc | grep -q 200; then
+              echo "API is up"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "API did not become ready in time"
+          docker compose logs
+          exit 1
+
+      - run: npm run test:auth
+
+      - name: Show container logs on failure
+        if: failure()
+        run: docker compose logs
+
+      - name: Tear down
+        if: always()
+        run: docker compose down -v
+
+  ai-review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: uv-0211/ai-code-review@v1
+        with:
+          pr-url: ${{ github.event.pull_request.html_url }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          max-issues: '5'
+          max-iterations: '2'

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ NestJS backend for a home music library management app.
   - **Albums**
   - **Favorites**
 
+- Pagination, search, and sorting on catalog list endpoints (`/track`, `/artist`, `/album`):
+  - `page`, `limit` — page number and page size (`limit` capped at 100)
+  - `search` — case-insensitive substring match on `name`
+  - `sortBy`, `sortOrder` — sortable fields differ per resource (see table below)
+  - responses are returned as `{ items, total, page, limit, totalPages }`
+
 ## Installation
 
 ### Clone the Repository
@@ -103,7 +109,7 @@ docker compose up --build
 
 | Method | Endpoint     | Description      |
 | ------ | ------------ | ---------------- |
-| GET    | `/track`     | Get all tracks   |
+| GET    | `/track`     | Get a paginated list of tracks. Query: `page`, `limit`, `search`, `sortBy` (`name` \| `duration`), `sortOrder` (`asc` \| `desc`) |
 | GET    | `/track/:id` | Get track by ID  |
 | POST   | `/track`     | Create new track |
 | PUT    | `/track/:id` | Update track     |
@@ -113,7 +119,7 @@ docker compose up --build
 
 | Method | Endpoint      | Description       |
 | ------ | ------------- | ----------------- |
-| GET    | `/artist`     | Get all artists   |
+| GET    | `/artist`     | Get a paginated list of artists. Query: `page`, `limit`, `search`, `sortBy` (`name`), `sortOrder` (`asc` \| `desc`) |
 | GET    | `/artist/:id` | Get artist by ID  |
 | POST   | `/artist`     | Create new artist |
 | PUT    | `/artist/:id` | Update artist     |
@@ -123,7 +129,7 @@ docker compose up --build
 
 | Method | Endpoint     | Description      |
 | ------ | ------------ | ---------------- |
-| GET    | `/album`     | Get all albums   |
+| GET    | `/album`     | Get a paginated list of albums. Query: `page`, `limit`, `search`, `sortBy` (`name` \| `year`), `sortOrder` (`asc` \| `desc`) |
 | GET    | `/album/:id` | Get album by ID  |
 | POST   | `/album`     | Create new album |
 | PUT    | `/album/:id` | Update album     |

--- a/doc/api.yaml
+++ b/doc/api.yaml
@@ -8,6 +8,41 @@ servers:
   - url: /api
 
 components:
+  parameters:
+    pageParam:
+      name: page
+      in: query
+      required: false
+      description: Page number (1-based)
+      schema:
+        type: integer
+        minimum: 1
+        default: 1
+    limitParam:
+      name: limit
+      in: query
+      required: false
+      description: Number of items per page
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 100
+        default: 20
+    searchParam:
+      name: search
+      in: query
+      required: false
+      description: Case-insensitive substring search by name
+      schema:
+        type: string
+    sortOrderParam:
+      name: sortOrder
+      in: query
+      required: false
+      schema:
+        type: string
+        enum: [asc, desc]
+        default: asc
   schemas:
     User:
       type: object
@@ -104,6 +139,69 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Track'
+    PaginatedTracks:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Track'
+        total:
+          type: integer
+          example: 42
+        page:
+          type: integer
+          example: 1
+        limit:
+          type: integer
+          example: 20
+      required:
+        - items
+        - total
+        - page
+        - limit
+    PaginatedAlbums:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Album'
+        total:
+          type: integer
+          example: 42
+        page:
+          type: integer
+          example: 1
+        limit:
+          type: integer
+          example: 20
+      required:
+        - items
+        - total
+        - page
+        - limit
+    PaginatedArtists:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/Artist'
+        total:
+          type: integer
+          example: 42
+        page:
+          type: integer
+          example: 1
+        limit:
+          type: integer
+          example: 20
+      required:
+        - items
+        - total
+        - page
+        - limit
   responses:
     UnauthorizedError:
       description: Access token is missing or invalid
@@ -339,16 +437,28 @@ paths:
       tags:
         - Track
       summary: Get tracks list
-      description: Gets all library tracks list
+      description: Gets a paginated list of library tracks, with optional search and sorting
+      parameters:
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/searchParam'
+        - name: sortBy
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [name, duration]
+            default: name
+        - $ref: '#/components/parameters/sortOrderParam'
       responses:
         200:
           description: Successful operation
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Track'
+                $ref: '#/components/schemas/PaginatedTracks'
+        400:
+          description: Bad request. Invalid pagination query parameters
         401:
           $ref: '#/components/responses/UnauthorizedError'
     post:
@@ -497,16 +607,28 @@ paths:
       tags:
         - Album
       summary: Get albums list
-      description: Gets all library albums list
+      description: Gets a paginated list of library albums, with optional search and sorting
+      parameters:
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/searchParam'
+        - name: sortBy
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [name, year]
+            default: name
+        - $ref: '#/components/parameters/sortOrderParam'
       responses:
         200:
           description: Successful operation
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Album'
+                $ref: '#/components/schemas/PaginatedAlbums'
+        400:
+          description: Bad request. Invalid pagination query parameters
         401:
           $ref: '#/components/responses/UnauthorizedError'
     post:
@@ -626,16 +748,28 @@ paths:
       tags:
         - Artist
       summary: Get all artists
-      description: Gets all artists
+      description: Gets a paginated list of artists, with optional search and sorting
+      parameters:
+        - $ref: '#/components/parameters/pageParam'
+        - $ref: '#/components/parameters/limitParam'
+        - $ref: '#/components/parameters/searchParam'
+        - name: sortBy
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [name]
+            default: name
+        - $ref: '#/components/parameters/sortOrderParam'
       responses:
         200:
           description: Successful operation
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Artist'
+                $ref: '#/components/schemas/PaginatedArtists'
+        400:
+          description: Bad request. Invalid pagination query parameters
         401:
           $ref: '#/components/responses/UnauthorizedError'
     post:

--- a/doc/api.yaml
+++ b/doc/api.yaml
@@ -155,11 +155,15 @@ components:
         limit:
           type: integer
           example: 20
+        totalPages:
+          type: integer
+          example: 3
       required:
         - items
         - total
         - page
         - limit
+        - totalPages
     PaginatedAlbums:
       type: object
       properties:
@@ -176,11 +180,15 @@ components:
         limit:
           type: integer
           example: 20
+        totalPages:
+          type: integer
+          example: 3
       required:
         - items
         - total
         - page
         - limit
+        - totalPages
     PaginatedArtists:
       type: object
       properties:
@@ -197,11 +205,15 @@ components:
         limit:
           type: integer
           example: 20
+        totalPages:
+          type: integer
+          example: 3
       required:
         - items
         - total
         - page
         - limit
+        - totalPages
   responses:
     UnauthorizedError:
       description: Access token is missing or invalid

--- a/doc/api.yaml
+++ b/doc/api.yaml
@@ -139,81 +139,59 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Track'
+    PaginationMeta:
+      type: object
+      properties:
+        total:
+          type: integer
+          example: 42
+        page:
+          type: integer
+          example: 1
+        limit:
+          type: integer
+          example: 20
+        totalPages:
+          type: integer
+          example: 3
+      required:
+        - total
+        - page
+        - limit
+        - totalPages
     PaginatedTracks:
-      type: object
-      properties:
-        items:
-          type: array
-          items:
-            $ref: '#/components/schemas/Track'
-        total:
-          type: integer
-          example: 42
-        page:
-          type: integer
-          example: 1
-        limit:
-          type: integer
-          example: 20
-        totalPages:
-          type: integer
-          example: 3
-      required:
-        - items
-        - total
-        - page
-        - limit
-        - totalPages
+      allOf:
+        - $ref: '#/components/schemas/PaginationMeta'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/Track'
+          required:
+            - items
     PaginatedAlbums:
-      type: object
-      properties:
-        items:
-          type: array
-          items:
-            $ref: '#/components/schemas/Album'
-        total:
-          type: integer
-          example: 42
-        page:
-          type: integer
-          example: 1
-        limit:
-          type: integer
-          example: 20
-        totalPages:
-          type: integer
-          example: 3
-      required:
-        - items
-        - total
-        - page
-        - limit
-        - totalPages
+      allOf:
+        - $ref: '#/components/schemas/PaginationMeta'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/Album'
+          required:
+            - items
     PaginatedArtists:
-      type: object
-      properties:
-        items:
-          type: array
-          items:
-            $ref: '#/components/schemas/Artist'
-        total:
-          type: integer
-          example: 42
-        page:
-          type: integer
-          example: 1
-        limit:
-          type: integer
-          example: 20
-        totalPages:
-          type: integer
-          example: 3
-      required:
-        - items
-        - total
-        - page
-        - limit
-        - totalPages
+      allOf:
+        - $ref: '#/components/schemas/PaginationMeta'
+        - type: object
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/Artist'
+          required:
+            - items
   responses:
     UnauthorizedError:
       description: Access token is missing or invalid

--- a/src/common/dto/pagination-query.dto.ts
+++ b/src/common/dto/pagination-query.dto.ts
@@ -1,0 +1,25 @@
+import { Type } from 'class-transformer';
+import { IsIn, IsInt, IsOptional, IsString, Max, Min } from 'class-validator';
+
+export class PaginationQueryDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  limit: number = 20;
+
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sortOrder: 'asc' | 'desc' = 'asc';
+}

--- a/src/modules/album/album.controller.ts
+++ b/src/modules/album/album.controller.ts
@@ -7,10 +7,12 @@ import {
   Param,
   Post,
   Put,
+  Query,
 } from '@nestjs/common';
 import { AlbumService } from './album.service';
 import { CreateAlbumDto } from './dto/create-album.dto';
 import { UpdateAlbumDto } from './dto/update-album.dto';
+import { FindAlbumsQueryDto } from './dto/find-albums-query.dto';
 
 @Controller('album')
 export class AlbumController {
@@ -22,8 +24,8 @@ export class AlbumController {
   }
 
   @Get()
-  async findAll() {
-    return await this.albumService.findAll();
+  async findAll(@Query() query: FindAlbumsQueryDto) {
+    return await this.albumService.findAll(query);
   }
 
   @Get(':id')

--- a/src/modules/album/album.service.ts
+++ b/src/modules/album/album.service.ts
@@ -7,7 +7,10 @@ import { PrismaService } from 'src/prisma/prisma.service';
 import { isValidUUID } from 'src/utils/validateUUID';
 import { Album, Prisma } from '@prisma/client';
 import { PaginatedResult, getSkipTake } from 'src/utils/pagination';
-import { FindAlbumsQueryDto } from './dto/find-albums-query.dto';
+import {
+  ALBUM_SORT_FIELDS,
+  FindAlbumsQueryDto,
+} from './dto/find-albums-query.dto';
 
 @Injectable()
 export class AlbumService {
@@ -19,6 +22,10 @@ export class AlbumService {
 
   async findAll(query: FindAlbumsQueryDto): Promise<PaginatedResult<Album>> {
     const { page, limit, search, sortBy, sortOrder } = query;
+
+    if (!ALBUM_SORT_FIELDS.includes(sortBy)) {
+      throw new BadRequestException('Invalid sortBy field');
+    }
 
     const where: Prisma.AlbumWhereInput = search
       ? { name: { contains: search, mode: 'insensitive' } }
@@ -33,7 +40,13 @@ export class AlbumService {
       this.prisma.album.count({ where }),
     ]);
 
-    return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: limit > 0 ? Math.ceil(total / limit) : 0,
+    };
   }
 
   async findById(id: string) {

--- a/src/modules/album/album.service.ts
+++ b/src/modules/album/album.service.ts
@@ -24,7 +24,7 @@ export class AlbumService {
       ? { name: { contains: search, mode: 'insensitive' } }
       : {};
 
-    const [items, total] = await this.prisma.$transaction([
+    const [items, total] = await Promise.all([
       this.prisma.album.findMany({
         where,
         orderBy: { [sortBy]: sortOrder },
@@ -33,7 +33,7 @@ export class AlbumService {
       this.prisma.album.count({ where }),
     ]);
 
-    return { items, total, page, limit };
+    return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
   }
 
   async findById(id: string) {

--- a/src/modules/album/album.service.ts
+++ b/src/modules/album/album.service.ts
@@ -5,7 +5,9 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { isValidUUID } from 'src/utils/validateUUID';
-import { Prisma } from '@prisma/client';
+import { Album, Prisma } from '@prisma/client';
+import { PaginatedResult, getSkipTake } from 'src/utils/pagination';
+import { FindAlbumsQueryDto } from './dto/find-albums-query.dto';
 
 @Injectable()
 export class AlbumService {
@@ -15,8 +17,23 @@ export class AlbumService {
     return await this.prisma.album.create({ data });
   }
 
-  async findAll() {
-    return await this.prisma.album.findMany();
+  async findAll(query: FindAlbumsQueryDto): Promise<PaginatedResult<Album>> {
+    const { page, limit, search, sortBy, sortOrder } = query;
+
+    const where: Prisma.AlbumWhereInput = search
+      ? { name: { contains: search, mode: 'insensitive' } }
+      : {};
+
+    const [items, total] = await this.prisma.$transaction([
+      this.prisma.album.findMany({
+        where,
+        orderBy: { [sortBy]: sortOrder },
+        ...getSkipTake(page, limit),
+      }),
+      this.prisma.album.count({ where }),
+    ]);
+
+    return { items, total, page, limit };
   }
 
   async findById(id: string) {

--- a/src/modules/album/dto/find-albums-query.dto.ts
+++ b/src/modules/album/dto/find-albums-query.dto.ts
@@ -1,0 +1,11 @@
+import { IsIn, IsOptional } from 'class-validator';
+import { PaginationQueryDto } from 'src/common/dto/pagination-query.dto';
+
+const ALBUM_SORT_FIELDS = ['name', 'year'] as const;
+export type AlbumSortField = (typeof ALBUM_SORT_FIELDS)[number];
+
+export class FindAlbumsQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsIn(ALBUM_SORT_FIELDS)
+  sortBy: AlbumSortField = 'name';
+}

--- a/src/modules/album/dto/find-albums-query.dto.ts
+++ b/src/modules/album/dto/find-albums-query.dto.ts
@@ -1,7 +1,7 @@
 import { IsIn, IsOptional } from 'class-validator';
 import { PaginationQueryDto } from 'src/common/dto/pagination-query.dto';
 
-const ALBUM_SORT_FIELDS = ['name', 'year'] as const;
+export const ALBUM_SORT_FIELDS = ['name', 'year'] as const;
 export type AlbumSortField = (typeof ALBUM_SORT_FIELDS)[number];
 
 export class FindAlbumsQueryDto extends PaginationQueryDto {

--- a/src/modules/artist/artist.controller.ts
+++ b/src/modules/artist/artist.controller.ts
@@ -7,10 +7,12 @@ import {
   Param,
   Post,
   Put,
+  Query,
 } from '@nestjs/common';
 import { ArtistService } from './artist.service';
 import { CreateArtistDto } from './dto/create-artist.dto';
 import { UpdateArtistDto } from './dto/update-artist.dto';
+import { FindArtistsQueryDto } from './dto/find-artists-query.dto';
 
 @Controller('artist')
 export class ArtistController {
@@ -22,8 +24,8 @@ export class ArtistController {
   }
 
   @Get()
-  async findAll() {
-    return await this.artistService.findAll();
+  async findAll(@Query() query: FindArtistsQueryDto) {
+    return await this.artistService.findAll(query);
   }
 
   @Get(':id')

--- a/src/modules/artist/artist.service.ts
+++ b/src/modules/artist/artist.service.ts
@@ -24,7 +24,7 @@ export class ArtistService {
       ? { name: { contains: search, mode: 'insensitive' } }
       : {};
 
-    const [items, total] = await this.prisma.$transaction([
+    const [items, total] = await Promise.all([
       this.prisma.artist.findMany({
         where,
         orderBy: { [sortBy]: sortOrder },
@@ -33,7 +33,7 @@ export class ArtistService {
       this.prisma.artist.count({ where }),
     ]);
 
-    return { items, total, page, limit };
+    return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
   }
 
   async findById(id: string) {

--- a/src/modules/artist/artist.service.ts
+++ b/src/modules/artist/artist.service.ts
@@ -7,7 +7,10 @@ import { isValidUUID } from 'src/utils/validateUUID';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { Artist, Prisma } from '@prisma/client';
 import { PaginatedResult, getSkipTake } from 'src/utils/pagination';
-import { FindArtistsQueryDto } from './dto/find-artists-query.dto';
+import {
+  ARTIST_SORT_FIELDS,
+  FindArtistsQueryDto,
+} from './dto/find-artists-query.dto';
 
 @Injectable()
 export class ArtistService {
@@ -19,6 +22,10 @@ export class ArtistService {
 
   async findAll(query: FindArtistsQueryDto): Promise<PaginatedResult<Artist>> {
     const { page, limit, search, sortBy, sortOrder } = query;
+
+    if (!ARTIST_SORT_FIELDS.includes(sortBy)) {
+      throw new BadRequestException('Invalid sortBy field');
+    }
 
     const where: Prisma.ArtistWhereInput = search
       ? { name: { contains: search, mode: 'insensitive' } }
@@ -33,7 +40,13 @@ export class ArtistService {
       this.prisma.artist.count({ where }),
     ]);
 
-    return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: limit > 0 ? Math.ceil(total / limit) : 0,
+    };
   }
 
   async findById(id: string) {

--- a/src/modules/artist/artist.service.ts
+++ b/src/modules/artist/artist.service.ts
@@ -5,7 +5,9 @@ import {
 } from '@nestjs/common';
 import { isValidUUID } from 'src/utils/validateUUID';
 import { PrismaService } from 'src/prisma/prisma.service';
-import { Prisma } from '@prisma/client';
+import { Artist, Prisma } from '@prisma/client';
+import { PaginatedResult, getSkipTake } from 'src/utils/pagination';
+import { FindArtistsQueryDto } from './dto/find-artists-query.dto';
 
 @Injectable()
 export class ArtistService {
@@ -15,8 +17,23 @@ export class ArtistService {
     return await this.prisma.artist.create({ data });
   }
 
-  async findAll() {
-    return await this.prisma.artist.findMany();
+  async findAll(query: FindArtistsQueryDto): Promise<PaginatedResult<Artist>> {
+    const { page, limit, search, sortBy, sortOrder } = query;
+
+    const where: Prisma.ArtistWhereInput = search
+      ? { name: { contains: search, mode: 'insensitive' } }
+      : {};
+
+    const [items, total] = await this.prisma.$transaction([
+      this.prisma.artist.findMany({
+        where,
+        orderBy: { [sortBy]: sortOrder },
+        ...getSkipTake(page, limit),
+      }),
+      this.prisma.artist.count({ where }),
+    ]);
+
+    return { items, total, page, limit };
   }
 
   async findById(id: string) {

--- a/src/modules/artist/dto/find-artists-query.dto.ts
+++ b/src/modules/artist/dto/find-artists-query.dto.ts
@@ -1,0 +1,11 @@
+import { IsIn, IsOptional } from 'class-validator';
+import { PaginationQueryDto } from 'src/common/dto/pagination-query.dto';
+
+const ARTIST_SORT_FIELDS = ['name'] as const;
+export type ArtistSortField = (typeof ARTIST_SORT_FIELDS)[number];
+
+export class FindArtistsQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsIn(ARTIST_SORT_FIELDS)
+  sortBy: ArtistSortField = 'name';
+}

--- a/src/modules/artist/dto/find-artists-query.dto.ts
+++ b/src/modules/artist/dto/find-artists-query.dto.ts
@@ -1,7 +1,7 @@
 import { IsIn, IsOptional } from 'class-validator';
 import { PaginationQueryDto } from 'src/common/dto/pagination-query.dto';
 
-const ARTIST_SORT_FIELDS = ['name'] as const;
+export const ARTIST_SORT_FIELDS = ['name'] as const;
 export type ArtistSortField = (typeof ARTIST_SORT_FIELDS)[number];
 
 export class FindArtistsQueryDto extends PaginationQueryDto {

--- a/src/modules/track/dto/find-tracks-query.dto.ts
+++ b/src/modules/track/dto/find-tracks-query.dto.ts
@@ -1,7 +1,7 @@
 import { IsIn, IsOptional } from 'class-validator';
 import { PaginationQueryDto } from 'src/common/dto/pagination-query.dto';
 
-const TRACK_SORT_FIELDS = ['name', 'duration'] as const;
+export const TRACK_SORT_FIELDS = ['name', 'duration'] as const;
 export type TrackSortField = (typeof TRACK_SORT_FIELDS)[number];
 
 export class FindTracksQueryDto extends PaginationQueryDto {

--- a/src/modules/track/dto/find-tracks-query.dto.ts
+++ b/src/modules/track/dto/find-tracks-query.dto.ts
@@ -1,0 +1,11 @@
+import { IsIn, IsOptional } from 'class-validator';
+import { PaginationQueryDto } from 'src/common/dto/pagination-query.dto';
+
+const TRACK_SORT_FIELDS = ['name', 'duration'] as const;
+export type TrackSortField = (typeof TRACK_SORT_FIELDS)[number];
+
+export class FindTracksQueryDto extends PaginationQueryDto {
+  @IsOptional()
+  @IsIn(TRACK_SORT_FIELDS)
+  sortBy: TrackSortField = 'name';
+}

--- a/src/modules/track/track.controller.ts
+++ b/src/modules/track/track.controller.ts
@@ -7,10 +7,12 @@ import {
   Param,
   Post,
   Put,
+  Query,
 } from '@nestjs/common';
 import { TrackService } from './track.service';
 import { CreateTrackDto } from './dto/create-track.dto';
 import { UpdateTrackDto } from './dto/update-track.dto';
+import { FindTracksQueryDto } from './dto/find-tracks-query.dto';
 
 @Controller('track')
 export class TrackController {
@@ -22,8 +24,8 @@ export class TrackController {
   }
 
   @Get()
-  async findAll() {
-    return await this.trackService.findAll();
+  async findAll(@Query() query: FindTracksQueryDto) {
+    return await this.trackService.findAll(query);
   }
 
   @Get(':id')

--- a/src/modules/track/track.service.ts
+++ b/src/modules/track/track.service.ts
@@ -3,9 +3,11 @@ import {
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
-import { Prisma } from '@prisma/client';
+import { Prisma, Track } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { isValidUUID } from 'src/utils/validateUUID';
+import { PaginatedResult, getSkipTake } from 'src/utils/pagination';
+import { FindTracksQueryDto } from './dto/find-tracks-query.dto';
 
 @Injectable()
 export class TrackService {
@@ -15,8 +17,23 @@ export class TrackService {
     return await this.prisma.track.create({ data });
   }
 
-  async findAll() {
-    return await this.prisma.track.findMany();
+  async findAll(query: FindTracksQueryDto): Promise<PaginatedResult<Track>> {
+    const { page, limit, search, sortBy, sortOrder } = query;
+
+    const where: Prisma.TrackWhereInput = search
+      ? { name: { contains: search, mode: 'insensitive' } }
+      : {};
+
+    const [items, total] = await this.prisma.$transaction([
+      this.prisma.track.findMany({
+        where,
+        orderBy: { [sortBy]: sortOrder },
+        ...getSkipTake(page, limit),
+      }),
+      this.prisma.track.count({ where }),
+    ]);
+
+    return { items, total, page, limit };
   }
 
   async findById(id: string) {

--- a/src/modules/track/track.service.ts
+++ b/src/modules/track/track.service.ts
@@ -7,7 +7,10 @@ import { Prisma, Track } from '@prisma/client';
 import { PrismaService } from 'src/prisma/prisma.service';
 import { isValidUUID } from 'src/utils/validateUUID';
 import { PaginatedResult, getSkipTake } from 'src/utils/pagination';
-import { FindTracksQueryDto } from './dto/find-tracks-query.dto';
+import {
+  TRACK_SORT_FIELDS,
+  FindTracksQueryDto,
+} from './dto/find-tracks-query.dto';
 
 @Injectable()
 export class TrackService {
@@ -19,6 +22,10 @@ export class TrackService {
 
   async findAll(query: FindTracksQueryDto): Promise<PaginatedResult<Track>> {
     const { page, limit, search, sortBy, sortOrder } = query;
+
+    if (!TRACK_SORT_FIELDS.includes(sortBy)) {
+      throw new BadRequestException('Invalid sortBy field');
+    }
 
     const where: Prisma.TrackWhereInput = search
       ? { name: { contains: search, mode: 'insensitive' } }
@@ -33,7 +40,13 @@ export class TrackService {
       this.prisma.track.count({ where }),
     ]);
 
-    return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
+    return {
+      items,
+      total,
+      page,
+      limit,
+      totalPages: limit > 0 ? Math.ceil(total / limit) : 0,
+    };
   }
 
   async findById(id: string) {

--- a/src/modules/track/track.service.ts
+++ b/src/modules/track/track.service.ts
@@ -24,7 +24,7 @@ export class TrackService {
       ? { name: { contains: search, mode: 'insensitive' } }
       : {};
 
-    const [items, total] = await this.prisma.$transaction([
+    const [items, total] = await Promise.all([
       this.prisma.track.findMany({
         where,
         orderBy: { [sortBy]: sortOrder },
@@ -33,7 +33,7 @@ export class TrackService {
       this.prisma.track.count({ where }),
     ]);
 
-    return { items, total, page, limit };
+    return { items, total, page, limit, totalPages: Math.ceil(total / limit) };
   }
 
   async findById(id: string) {

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -1,0 +1,10 @@
+export interface PaginatedResult<T> {
+  items: T[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export function getSkipTake(page: number, limit: number) {
+  return { skip: (page - 1) * limit, take: limit };
+}

--- a/src/utils/pagination.ts
+++ b/src/utils/pagination.ts
@@ -3,6 +3,7 @@ export interface PaginatedResult<T> {
   total: number;
   page: number;
   limit: number;
+  totalPages: number;
 }
 
 export function getSkipTake(page: number, limit: number) {

--- a/test/albums.e2e.spec.ts
+++ b/test/albums.e2e.spec.ts
@@ -57,6 +57,7 @@ describe('Album (e2e)', () => {
       expect(typeof response.body.total).toBe('number');
       expect(response.body.page).toBe(1);
       expect(response.body.limit).toBe(20);
+      expect(typeof response.body.totalPages).toBe('number');
     });
 
     it('should correctly filter albums by search and respect custom limit', async () => {
@@ -76,20 +77,24 @@ describe('Album (e2e)', () => {
 
       expect(creationResponse.statusCode).toBe(StatusCodes.CREATED);
 
-      const searchResponse = await unauthorizedRequest
-        .get(`${albumsRoutes.getAll}?search=${uniqueAlbumDto.name}&limit=1`)
-        .set(commonHeaders);
+      try {
+        const searchResponse = await unauthorizedRequest
+          .get(
+            `${albumsRoutes.getAll}?search=${encodeURIComponent(uniqueAlbumDto.name)}&limit=1`,
+          )
+          .set(commonHeaders);
 
-      expect(searchResponse.status).toBe(StatusCodes.OK);
-      expect(searchResponse.body.items).toHaveLength(1);
-      expect(searchResponse.body.items[0].name).toBe(uniqueAlbumDto.name);
-      expect(searchResponse.body.limit).toBe(1);
+        expect(searchResponse.status).toBe(StatusCodes.OK);
+        expect(searchResponse.body.items).toHaveLength(1);
+        expect(searchResponse.body.items[0].name).toBe(uniqueAlbumDto.name);
+        expect(searchResponse.body.limit).toBe(1);
+      } finally {
+        const cleanupResponse = await unauthorizedRequest
+          .delete(albumsRoutes.delete(id))
+          .set(commonHeaders);
 
-      const cleanupResponse = await unauthorizedRequest
-        .delete(albumsRoutes.delete(id))
-        .set(commonHeaders);
-
-      expect(cleanupResponse.statusCode).toBe(StatusCodes.NO_CONTENT);
+        expect(cleanupResponse.statusCode).toBe(StatusCodes.NO_CONTENT);
+      }
     });
 
     it('should respond with BAD_REQUEST status code for invalid pagination query', async () => {

--- a/test/albums.e2e.spec.ts
+++ b/test/albums.e2e.spec.ts
@@ -53,7 +53,51 @@ describe('Album (e2e)', () => {
         .set(commonHeaders);
 
       expect(response.status).toBe(StatusCodes.OK);
-      expect(response.body).toBeInstanceOf(Array);
+      expect(response.body.items).toBeInstanceOf(Array);
+      expect(typeof response.body.total).toBe('number');
+      expect(response.body.page).toBe(1);
+      expect(response.body.limit).toBe(20);
+    });
+
+    it('should correctly filter albums by search and respect custom limit', async () => {
+      // Unique name so `search` (case-insensitive contains) can't accidentally
+      // match leftover records from other tests sharing this persistent DB
+      const uniqueAlbumDto = {
+        ...createAlbumDto,
+        name: 'PAGINATION_SEARCH_ALBUM',
+      };
+
+      const creationResponse = await unauthorizedRequest
+        .post(albumsRoutes.create)
+        .set(commonHeaders)
+        .send(uniqueAlbumDto);
+
+      const { id } = creationResponse.body;
+
+      expect(creationResponse.statusCode).toBe(StatusCodes.CREATED);
+
+      const searchResponse = await unauthorizedRequest
+        .get(`${albumsRoutes.getAll}?search=${uniqueAlbumDto.name}&limit=1`)
+        .set(commonHeaders);
+
+      expect(searchResponse.status).toBe(StatusCodes.OK);
+      expect(searchResponse.body.items).toHaveLength(1);
+      expect(searchResponse.body.items[0].name).toBe(uniqueAlbumDto.name);
+      expect(searchResponse.body.limit).toBe(1);
+
+      const cleanupResponse = await unauthorizedRequest
+        .delete(albumsRoutes.delete(id))
+        .set(commonHeaders);
+
+      expect(cleanupResponse.statusCode).toBe(StatusCodes.NO_CONTENT);
+    });
+
+    it('should respond with BAD_REQUEST status code for invalid pagination query', async () => {
+      const response = await unauthorizedRequest
+        .get(`${albumsRoutes.getAll}?limit=0`)
+        .set(commonHeaders);
+
+      expect(response.status).toBe(StatusCodes.BAD_REQUEST);
     });
 
     it('should correctly get album by id', async () => {

--- a/test/artists.e2e.spec.ts
+++ b/test/artists.e2e.spec.ts
@@ -51,6 +51,7 @@ describe('artist (e2e)', () => {
       expect(typeof response.body.total).toBe('number');
       expect(response.body.page).toBe(1);
       expect(response.body.limit).toBe(20);
+      expect(typeof response.body.totalPages).toBe('number');
     });
 
     it('should correctly filter artists by search and respect custom limit', async () => {
@@ -70,20 +71,24 @@ describe('artist (e2e)', () => {
 
       expect(creationResponse.statusCode).toBe(StatusCodes.CREATED);
 
-      const searchResponse = await unauthorizedRequest
-        .get(`${artistsRoutes.getAll}?search=${uniqueArtistDto.name}&limit=1`)
-        .set(commonHeaders);
+      try {
+        const searchResponse = await unauthorizedRequest
+          .get(
+            `${artistsRoutes.getAll}?search=${encodeURIComponent(uniqueArtistDto.name)}&limit=1`,
+          )
+          .set(commonHeaders);
 
-      expect(searchResponse.status).toBe(StatusCodes.OK);
-      expect(searchResponse.body.items).toHaveLength(1);
-      expect(searchResponse.body.items[0].name).toBe(uniqueArtistDto.name);
-      expect(searchResponse.body.limit).toBe(1);
+        expect(searchResponse.status).toBe(StatusCodes.OK);
+        expect(searchResponse.body.items).toHaveLength(1);
+        expect(searchResponse.body.items[0].name).toBe(uniqueArtistDto.name);
+        expect(searchResponse.body.limit).toBe(1);
+      } finally {
+        const cleanupResponse = await unauthorizedRequest
+          .delete(artistsRoutes.delete(id))
+          .set(commonHeaders);
 
-      const cleanupResponse = await unauthorizedRequest
-        .delete(artistsRoutes.delete(id))
-        .set(commonHeaders);
-
-      expect(cleanupResponse.statusCode).toBe(StatusCodes.NO_CONTENT);
+        expect(cleanupResponse.statusCode).toBe(StatusCodes.NO_CONTENT);
+      }
     });
 
     it('should respond with BAD_REQUEST status code for invalid pagination query', async () => {

--- a/test/artists.e2e.spec.ts
+++ b/test/artists.e2e.spec.ts
@@ -47,7 +47,51 @@ describe('artist (e2e)', () => {
         .set(commonHeaders);
 
       expect(response.status).toBe(StatusCodes.OK);
-      expect(response.body).toBeInstanceOf(Array);
+      expect(response.body.items).toBeInstanceOf(Array);
+      expect(typeof response.body.total).toBe('number');
+      expect(response.body.page).toBe(1);
+      expect(response.body.limit).toBe(20);
+    });
+
+    it('should correctly filter artists by search and respect custom limit', async () => {
+      // Unique name so `search` (case-insensitive contains) can't accidentally
+      // match leftover records from other tests sharing this persistent DB
+      const uniqueArtistDto = {
+        ...createArtistDto,
+        name: 'PAGINATION_SEARCH_ARTIST',
+      };
+
+      const creationResponse = await unauthorizedRequest
+        .post(artistsRoutes.create)
+        .set(commonHeaders)
+        .send(uniqueArtistDto);
+
+      const { id } = creationResponse.body;
+
+      expect(creationResponse.statusCode).toBe(StatusCodes.CREATED);
+
+      const searchResponse = await unauthorizedRequest
+        .get(`${artistsRoutes.getAll}?search=${uniqueArtistDto.name}&limit=1`)
+        .set(commonHeaders);
+
+      expect(searchResponse.status).toBe(StatusCodes.OK);
+      expect(searchResponse.body.items).toHaveLength(1);
+      expect(searchResponse.body.items[0].name).toBe(uniqueArtistDto.name);
+      expect(searchResponse.body.limit).toBe(1);
+
+      const cleanupResponse = await unauthorizedRequest
+        .delete(artistsRoutes.delete(id))
+        .set(commonHeaders);
+
+      expect(cleanupResponse.statusCode).toBe(StatusCodes.NO_CONTENT);
+    });
+
+    it('should respond with BAD_REQUEST status code for invalid pagination query', async () => {
+      const response = await unauthorizedRequest
+        .get(`${artistsRoutes.getAll}?limit=0`)
+        .set(commonHeaders);
+
+      expect(response.status).toBe(StatusCodes.BAD_REQUEST);
     });
 
     it('should correctly get artist by id', async () => {

--- a/test/tracks.e2e.spec.ts
+++ b/test/tracks.e2e.spec.ts
@@ -53,6 +53,7 @@ describe('Tracks (e2e)', () => {
       expect(typeof response.body.total).toBe('number');
       expect(response.body.page).toBe(1);
       expect(response.body.limit).toBe(20);
+      expect(typeof response.body.totalPages).toBe('number');
     });
 
     it('should correctly filter tracks by search and respect custom limit', async () => {
@@ -72,20 +73,24 @@ describe('Tracks (e2e)', () => {
 
       expect(creationResponse.statusCode).toBe(StatusCodes.CREATED);
 
-      const searchResponse = await unauthorizedRequest
-        .get(`${tracksRoutes.getAll}?search=${uniqueTrackDto.name}&limit=1`)
-        .set(commonHeaders);
+      try {
+        const searchResponse = await unauthorizedRequest
+          .get(
+            `${tracksRoutes.getAll}?search=${encodeURIComponent(uniqueTrackDto.name)}&limit=1`,
+          )
+          .set(commonHeaders);
 
-      expect(searchResponse.status).toBe(StatusCodes.OK);
-      expect(searchResponse.body.items).toHaveLength(1);
-      expect(searchResponse.body.items[0].name).toBe(uniqueTrackDto.name);
-      expect(searchResponse.body.limit).toBe(1);
+        expect(searchResponse.status).toBe(StatusCodes.OK);
+        expect(searchResponse.body.items).toHaveLength(1);
+        expect(searchResponse.body.items[0].name).toBe(uniqueTrackDto.name);
+        expect(searchResponse.body.limit).toBe(1);
+      } finally {
+        const cleanupResponse = await unauthorizedRequest
+          .delete(tracksRoutes.delete(id))
+          .set(commonHeaders);
 
-      const cleanupResponse = await unauthorizedRequest
-        .delete(tracksRoutes.delete(id))
-        .set(commonHeaders);
-
-      expect(cleanupResponse.statusCode).toBe(StatusCodes.NO_CONTENT);
+        expect(cleanupResponse.statusCode).toBe(StatusCodes.NO_CONTENT);
+      }
     });
 
     it('should respond with BAD_REQUEST status code for invalid pagination query', async () => {

--- a/test/tracks.e2e.spec.ts
+++ b/test/tracks.e2e.spec.ts
@@ -49,7 +49,51 @@ describe('Tracks (e2e)', () => {
         .set(commonHeaders);
 
       expect(response.status).toBe(StatusCodes.OK);
-      expect(response.body).toBeInstanceOf(Array);
+      expect(response.body.items).toBeInstanceOf(Array);
+      expect(typeof response.body.total).toBe('number');
+      expect(response.body.page).toBe(1);
+      expect(response.body.limit).toBe(20);
+    });
+
+    it('should correctly filter tracks by search and respect custom limit', async () => {
+      // Unique name so `search` (case-insensitive contains) can't accidentally
+      // match leftover records from other tests sharing this persistent DB
+      const uniqueTrackDto = {
+        ...createTrackDto,
+        name: 'PAGINATION_SEARCH_TRACK',
+      };
+
+      const creationResponse = await unauthorizedRequest
+        .post(tracksRoutes.create)
+        .set(commonHeaders)
+        .send(uniqueTrackDto);
+
+      const { id } = creationResponse.body;
+
+      expect(creationResponse.statusCode).toBe(StatusCodes.CREATED);
+
+      const searchResponse = await unauthorizedRequest
+        .get(`${tracksRoutes.getAll}?search=${uniqueTrackDto.name}&limit=1`)
+        .set(commonHeaders);
+
+      expect(searchResponse.status).toBe(StatusCodes.OK);
+      expect(searchResponse.body.items).toHaveLength(1);
+      expect(searchResponse.body.items[0].name).toBe(uniqueTrackDto.name);
+      expect(searchResponse.body.limit).toBe(1);
+
+      const cleanupResponse = await unauthorizedRequest
+        .delete(tracksRoutes.delete(id))
+        .set(commonHeaders);
+
+      expect(cleanupResponse.statusCode).toBe(StatusCodes.NO_CONTENT);
+    });
+
+    it('should respond with BAD_REQUEST status code for invalid pagination query', async () => {
+      const response = await unauthorizedRequest
+        .get(`${tracksRoutes.getAll}?limit=0`)
+        .set(commonHeaders);
+
+      expect(response.status).toBe(StatusCodes.BAD_REQUEST);
     });
 
     it('should correctly get track by id', async () => {


### PR DESCRIPTION
- Add pagination, search and sorting to GET /track, /album, /artist (page, limit, search, sortBy, sortOrder query params)
- Response shape for these endpoints changed to { items, total, page, limit }
- Add reusable PaginationQueryDto + per-entity query DTOs, PaginatedResult<T> type, getSkipTake helper
- Update doc/api.yaml (Swagger) with new params and response schemas
- Update e2e tests for new response shape; add tests for search, custom limit, invalid query validation
- Add .github/workflows/ci.yml: e2e tests via docker-compose + AI code review action on every PR